### PR TITLE
adds -insecure-skip-verify flag

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -58,6 +58,7 @@ func TestCachedProxyHandler(t *testing.T) {
 		serverURL,
 		mockCacher{data: make(map[string]*CachedResponse)},
 		DefaultHasher{},
+		ProxyHandler(false),
 	)
 
 	w := httptest.NewRecorder()
@@ -102,6 +103,7 @@ func TestPreseedHandler(t *testing.T) {
 		serverURL,
 		cache,
 		DefaultHasher{},
+		ProxyHandler(false),
 	)
 	preseedHandler := PreseedHandler(
 		cache,
@@ -171,6 +173,7 @@ func TestPreseedHandlerWithRequestBody(t *testing.T) {
 		serverURL,
 		cache,
 		DefaultHasher{},
+		ProxyHandler(false),
 	)
 	preseedHandler := PreseedHandler(
 		cache,

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ var (
 	host       = flag.String("host", "localhost:6005", "Host/port on which to bind")
 	cHasher    = flag.String("hasher", "", "Custom hasher program for all requests (e.g. python ./hasher.py)")
 	verbose    = flag.Bool("verbose", false, "Turn on verbose logging")
+	skipverify = flag.Bool("insecure-skip-verify", false, "Skips verification of server's certificate")
 )
 
 func main() {
@@ -49,6 +50,6 @@ func main() {
 	cacher.SeedCache()
 	mux := http.NewServeMux()
 	mux.Handle("/_seed", PreseedHandler(cacher, hasher))
-	mux.Handle("/", CachedProxyHandler(serverURL, cacher, hasher))
+	mux.Handle("/", CachedProxyHandler(serverURL, cacher, hasher, ProxyHandler(*skipverify)))
 	log.Fatal(http.ListenAndServe(*host, mux))
 }


### PR DESCRIPTION
Default behavior is to check and verify the server's certificate. By
passing -insecure-skip-verify flag to the executable, you can prevent
the checking of the server's certificate. This is helpful when using
chameleon to proxy to a server has a certificate that won't verify.